### PR TITLE
fix: remove CTRU

### DIFF
--- a/ark-track-dbt/tests/raw.test:assert_same_max_date.sql
+++ b/ark-track-dbt/tests/raw.test:assert_same_max_date.sql
@@ -1,8 +1,11 @@
--- If this fails: the max date are different, aka: some funds are not updated
+-- If this fails: the max date are different, ie: some funds are not updated
 
 WITH base AS (
     SELECT fund, max(date) AS max_date
     FROM {{ source('raw', 'test') }}
+    -- CTRU is closed
+    -- ref: https://www.prnewswire.com/news-releases/ark-investment-management-llc-announces-it-will-close-the-ark-transparency-etf-the-fund-ticker-ctru-301589562.html
+    WHERE fund != 'CTRU'
     GROUP BY 1
 )
 

--- a/scripts/bq_load.py
+++ b/scripts/bq_load.py
@@ -18,7 +18,8 @@ Usage:
 from google.cloud import bigquery
 import argparse
 
-FUND_CODE_TO_UPLOAD = ["ARKF", "ARKG", "ARKK", "ARKQ", "ARKW", "IZRL", "PRNT", "ARKX", "CTRU"]
+# 2022 July: CTRU is removed
+FUND_CODE_TO_UPLOAD = ["ARKF", "ARKG", "ARKK", "ARKQ", "ARKW", "IZRL", "PRNT", "ARKX"]
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--date", "-d", help="file date YYYY-MM-DD, eg: 2021-02-19, match with date in data")


### PR DESCRIPTION
ARK closes CTRU around July 2022, hence remove it to avoid dbt test failure [since the data isn't updated]

https://www.prnewswire.com/news-releases/ark-investment-management-llc-announces-it-will-close-the-ark-transparency-etf-the-fund-ticker-ctru-301589562.html